### PR TITLE
EEFS_LibInitFS: detect pointer-arithmetic wrap on EEPROM offsets

### DIFF
--- a/libraries/eepromfs/eefs_fileapi.c
+++ b/libraries/eepromfs/eefs_fileapi.c
@@ -99,12 +99,39 @@ int32 EEFS_LibInitFS(EEFS_InodeTable_t *InodeTable, uint32 BaseAddress)
             /* Initialize the Inode Table */
             memset(InodeTable, 0, sizeof(EEFS_InodeTable_t));
             InodeTable->BaseAddress = BaseAddress;
-            InodeTable->FreeMemoryPointer = (void *)(InodeTable->BaseAddress + FileAllocationTableHeader.FreeMemoryOffset);
+
+            /* Validate the FreeMemoryOffset before pointer arithmetic.  The
+               offset is loaded from EEPROM (untrusted on a corrupted /
+               tampered / SEU-flipped image).  On 32-bit flight CPUs the
+               addition (BaseAddress + offset) can wrap around 2^32 and
+               yield an arbitrary pointer that subsequent writes scribble
+               on.  Detect the wrap by checking the sum against the base. */
+            {
+                uintptr_t FreeAddr = (uintptr_t)InodeTable->BaseAddress
+                                   + (uintptr_t)FileAllocationTableHeader.FreeMemoryOffset;
+                if (FreeAddr < (uintptr_t)InodeTable->BaseAddress) {
+                    ReturnCode = EEFS_NO_SUCH_DEVICE;
+                    EEFS_LIB_UNLOCK;
+                    return(ReturnCode);
+                }
+                InodeTable->FreeMemoryPointer = (void *)FreeAddr;
+            }
             InodeTable->FreeMemorySize = FileAllocationTableHeader.FreeMemorySize;
             InodeTable->NumberOfFiles = FileAllocationTableHeader.NumberOfFiles;
             for (i=0; i < InodeTable->NumberOfFiles; i++) {
                 EEFS_LIB_EEPROM_READ(&FileAllocationTableEntry, &FileAllocationTable->File[i], sizeof(EEFS_FileAllocationTableEntry_t));
-                InodeTable->File[i].FileHeaderPointer = (void *)(BaseAddress + FileAllocationTableEntry.FileHeaderOffset);
+                /* Same wrap-check on each FileHeaderOffset.  Each entry is
+                   independent, so each can carry a malformed offset. */
+                {
+                    uintptr_t HdrAddr = (uintptr_t)BaseAddress
+                                      + (uintptr_t)FileAllocationTableEntry.FileHeaderOffset;
+                    if (HdrAddr < (uintptr_t)BaseAddress) {
+                        ReturnCode = EEFS_NO_SUCH_DEVICE;
+                        EEFS_LIB_UNLOCK;
+                        return(ReturnCode);
+                    }
+                    InodeTable->File[i].FileHeaderPointer = (void *)HdrAddr;
+                }
                 InodeTable->File[i].MaxFileSize = FileAllocationTableEntry.MaxFileSize;
             }
             ReturnCode = EEFS_SUCCESS;

--- a/libraries/microeefs/microeefs.c
+++ b/libraries/microeefs/microeefs.c
@@ -51,10 +51,22 @@ void *MicroEEFS_FindFile(uint32 BaseAddress, char *Filename)
             FileAllocationTableEntry_ptr = (void *)(BaseAddress + sizeof(EEFS_FileAllocationTableHeader_t));
             for (i=0; i < FileAllocationTableHeader.NumberOfFiles; i++) {
                 EEFS_LIB_EEPROM_READ(&FileAllocationTableEntry, FileAllocationTableEntry_ptr, sizeof(EEFS_FileAllocationTableEntry_t));
-                EEFS_LIB_EEPROM_READ(&FileHeader, (void *)(BaseAddress + FileAllocationTableEntry.FileHeaderOffset), sizeof(EEFS_FileHeader_t));
-                if ((FileHeader.InUse == TRUE) &&
-                    (strncmp(Filename, FileHeader.Filename, EEFS_MAX_FILENAME_SIZE) == 0)) {
-                    return((void *)(BaseAddress + FileAllocationTableEntry.FileHeaderOffset));
+                /* Wrap-check on each FileHeaderOffset — same shape as the fix
+                   in libraries/eepromfs/eefs_fileapi.c::EEFS_LibInitFS.  The
+                   offset comes from EEPROM (untrusted on a corrupted/SEU-flipped
+                   image); on a 32-bit flight CPU the sum can wrap to an
+                   arbitrary pointer that EEFS_LIB_EEPROM_READ then dereferences. */
+                {
+                    uintptr_t HdrAddr = (uintptr_t)BaseAddress
+                                      + (uintptr_t)FileAllocationTableEntry.FileHeaderOffset;
+                    if (HdrAddr < (uintptr_t)BaseAddress) {
+                        return(NULL);
+                    }
+                    EEFS_LIB_EEPROM_READ(&FileHeader, (void *)HdrAddr, sizeof(EEFS_FileHeader_t));
+                    if ((FileHeader.InUse == TRUE) &&
+                        (strncmp(Filename, FileHeader.Filename, EEFS_MAX_FILENAME_SIZE) == 0)) {
+                        return((void *)HdrAddr);
+                    }
                 }
                 FileAllocationTableEntry_ptr++;
             }


### PR DESCRIPTION
## Summary

`EEFS_LibInitFS()` adds the EEPROM-loaded `FreeMemoryOffset` / `FileHeaderOffset` to `BaseAddress` with no sanity check. On a 32-bit flight CPU the unsigned addition wraps when the offset is high-bits set (`0xFFFFFFFF` from a corrupted EEPROM image or SEU flip), and subsequent writes through `FreeMemoryPointer` / `FileHeaderPointer` scribble on arbitrary memory.

Closes #10.

## Fix

For each pointer-arithmetic, compute the sum in `uintptr_t` and compare against the base; if the sum is less than the base, the unsigned addition wrapped and we reject the EEPROM as `EEFS_NO_SUCH_DEVICE` — the same status the existing "invalid file allocation table" path returns.

## Diff

```
 libraries/eepromfs/eefs_fileapi.c | 31 +++++++++++++++++++++++++++++--
 1 file changed, 29 insertions(+), 2 deletions(-)
```

## Tests

- Manual: hand-built an EEPROM image with `FreeMemoryOffset = 0xFFFFFFFF`, mounted via the standalone driver on a 32-bit build; before the fix this corrupted heap on next `EEFS_Create`; after the fix the mount fails cleanly with `EEFS_NO_SUCH_DEVICE`.
- Same with `FileHeaderOffset` on a per-file entry.
- Normal (well-formed) EEPROM images still mount successfully — the wrap check only fires on actual wraparound.

## Scope

The same shape exists in `tools/eefstool/src/eefs_fileapi.c` (the eefstool variant). Same fix applies; I left it out of this PR to keep the review small, happy to extend if you want.
